### PR TITLE
feat: add more flexible TYPO3 environment sync configuration and testing script

### DIFF
--- a/db_sync_tool/recipes/typo3.py
+++ b/db_sync_tool/recipes/typo3.py
@@ -30,14 +30,16 @@ def check_configuration(client):
         _db_config = parse_database_credentials(json.loads(stdout)['DB'])
     elif '.env' in _path:
         # Try to parse settings from .env file
+        if 'db' not in system.config[client]:
+            system.config[client]['db'] = {}
+
         _db_config = {
-            'name': get_database_setting_from_env(client, 'TYPO3_CONF_VARS__DB__Connections__Default__dbname', system.config[client]['path']),
-            'host': get_database_setting_from_env(client, 'TYPO3_CONF_VARS__DB__Connections__Default__host', system.config[client]['path']),
-            'password': get_database_setting_from_env(client, 'TYPO3_CONF_VARS__DB__Connections__Default__password', system.config[client]['path']),
-            'port': get_database_setting_from_env(client, 'TYPO3_CONF_VARS__DB__Connections__Default__port', system.config[client]['path'])
-            if get_database_setting_from_env(client, 'TYPO3_CONF_VARS__DB__Connections__Default__port',
-                                    system.config[client]['path']) != '' else 3306,
-            'user': get_database_setting_from_env(client, 'TYPO3_CONF_VARS__DB__Connections__Default__user', system.config[client]['path']),
+            'name': get_database_setting_from_env(client, system.config[client]['db'].get('name', 'TYPO3_CONF_VARS__DB__Connections__Default__dbname'), system.config[client]['path']),
+            'host': get_database_setting_from_env(client, system.config[client]['db'].get('host', 'TYPO3_CONF_VARS__DB__Connections__Default__host'), system.config[client]['path']),
+            'password': get_database_setting_from_env(client, system.config[client]['db'].get('password', 'TYPO3_CONF_VARS__DB__Connections__Default__password'), system.config[client]['path']),
+            'port': get_database_setting_from_env(client, system.config[client]['db'].get('port', 'TYPO3_CONF_VARS__DB__Connections__Default__port'), system.config[client]['path'])
+            if get_database_setting_from_env(client, system.config[client]['db'].get('port', 'TYPO3_CONF_VARS__DB__Connections__Default__port'), system.config[client]['path']) != '' else 3306,
+            'user': get_database_setting_from_env(client, system.config[client]['db'].get('user', 'TYPO3_CONF_VARS__DB__Connections__Default__user'), system.config[client]['path']),
         }
     elif 'AdditionalConfiguration.php' in _path:
         # Try to parse settings from AdditionalConfiguration.php file

--- a/tests/README.md
+++ b/tests/README.md
@@ -67,5 +67,7 @@ Select one of the following scenarios:
 - truncate
 - typo3_additional
 - typo3v7
+- typo3_env
+- typo3-2_env
 - wordpress
 - yaml

--- a/tests/scenario/typo3-2_env/sync-www1-to-local.json
+++ b/tests/scenario/typo3-2_env/sync-www1-to-local.json
@@ -1,0 +1,24 @@
+{
+  "type": "TYPO3",
+  "target": {
+    "path": "/var/www/html/tests/files/www2/typo3-2.env",
+    "db": {
+      "name": "TYPO3_DB_NAME",
+      "user": "TYPO3_DB_USER",
+      "password": "TYPO3_DB_PW",
+      "host": "TYPO3_DB_HOST"
+    }
+  },
+  "origin": {
+    "host": "www1",
+    "user": "user",
+    "password": "password",
+    "path": "/var/www/html/tests/files/www1/typo3-2.env",
+    "db": {
+      "name": "TYPO3_DB_NAME",
+      "user": "TYPO3_DB_USER",
+      "password": "TYPO3_DB_PW",
+      "host": "TYPO3_DB_HOST"
+    }
+  }
+}

--- a/tests/scenario/typo3-2_env/test.sh
+++ b/tests/scenario/typo3-2_env/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+#
+# Framework TYPO3 env
+#
+
+printf "\033[94m[TEST]\033[m Application: TYPO3 env"
+printf " \033[90m(Sync: WWW1 -> WWW2, Initiator: WWW2)\033[m"
+docker-compose exec www2 $1 /var/www/html/db_sync_tool -f /var/www/html/tests/scenario/typo3-2_env/sync-www1-to-local.json -y $2
+# Expecting 3 results in the database
+count=$(docker-compose exec db2 mysql -udb -pdb db -e 'SELECT COUNT(*) FROM person' | grep 3 | tr -d '[:space:]')
+if [[ $count == *'3'* ]]; then
+    echo " \033[92m✔\033[m"
+else
+    echo " \033[91m✘\033[m"
+    exit 1
+fi
+# sh helper/cleanup.sh


### PR DESCRIPTION
Change the default .env Variable Keys by adding the keys inside the "db" configuration array.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced database configuration handling to support reliable defaults and prevent potential misconfigurations.
- **Documentation**
	- Updated test documentation with additional TYPO3 scenarios.
- **Tests**
	- Introduced a new configuration setup and automated test script to validate TYPO3 environment synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->