### PR TITLE
Strip surrounding quotes from database URL

### DIFF
--- a/db_sync_tool/recipes/parsing.py
+++ b/db_sync_tool/recipes/parsing.py
@@ -12,6 +12,7 @@ Functions here are imported and used by the framework recipe modules.
 
 from urllib.parse import urlparse, unquote
 from db_sync_tool.utility.exceptions import ParsingError
+from db_sync_tool.utility.pure import remove_surrounding_quotes
 
 
 def parse_symfony_database_url(db_credentials: str) -> dict:
@@ -31,6 +32,9 @@ def parse_symfony_database_url(db_credentials: str) -> dict:
         url = db_credentials[len('DATABASE_URL='):]
     else:
         url = db_credentials
+
+    # Strip surrounding quotes (Symfony .env files commonly use them, see: https://symfony.com/doc/current/doctrine.html)
+    url = remove_surrounding_quotes(url)
 
     parsed = urlparse(url)
 


### PR DESCRIPTION
Added functionality to strip surrounding quotes from the database URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parsing of Symfony DATABASE_URL when the value is wrapped in surrounding quotes—quotes are now removed before parsing so scheme, credentials, host, port, and path are extracted correctly.
  * No changes to public interfaces or exported APIs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->